### PR TITLE
Offer more control over reqwest features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 jsonwebtoken = "8.1.1"
 tokio = { version = "1.22.0", features = ["sync"] }
 thiserror = "1.0.37"
-reqwest = { version = "0.11.13", features = ["json"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
 serde = {version = "1.0.147", features = ["derive"] }
 base64 = "0.13.1"
 log = "0.4.17"
@@ -21,5 +21,3 @@ log = "0.4.17"
 actix-web = {version = "4.2.1"}
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }
-
-


### PR DESCRIPTION
Currently, the reqwest dependency picks up all default features, enabling native-tls, which depends on OpenSSL. For projects that do not want to have an OpenSSL dependency, this is a problem.

This PR turns off default features for the reqwest dependency. Dependent projects can now choose whichever features of reqwest they want to enable (they need a dependency on reqwest to construct a `Validator`, anyway, so that is a natural place to customize its features).