### PR TITLE
Upgrade jsonwebtoken version to 9.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Batteries included validaton of Access Tokens from an OIDC Provid
 readme = "README.md"
 
 [dependencies]
-jsonwebtoken = "8.1.1"
+jsonwebtoken = "9"
 tokio = { version = "1.22.0", features = ["sync"] }
 thiserror = "1.0.37"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,8 @@ pub enum FetchError {
     InvalidJWK,
     #[error("Issuer URL Invalid")]
     IssuerParseError,
+    #[error("Invalid algorithm {0}")]
+    InvalidAlgorithm(String),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Since jsonwebtoken has a new major version, this PR upgrades its version to keep up.

The major change from oidc_jwt_validator is how the algorithm is derived from `KeyAlgorithm`.