### PR TITLE
Upgrade base64 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.22.0", features = ["sync"] }
 thiserror = "1.0.37"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
 serde = {version = "1.0.147", features = ["derive"] }
-base64 = "0.13.1"
+base64 = "0.22.0"
 log = "0.4.17"
 
 [dev-dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use jsonwebtoken::{
     jwk::{Jwk, KeyAlgorithm},
     Algorithm, DecodingKey,
@@ -67,7 +68,7 @@ fn to_algorithm(key_alg: KeyAlgorithm) -> Result<Algorithm, FetchError> {
 }
 
 fn b64_decode<T: AsRef<[u8]>>(input: T) -> Result<Vec<u8>, base64::DecodeError> {
-    base64::decode_config(input, base64::URL_SAFE_NO_PAD)
+    URL_SAFE_NO_PAD.decode(input)
 }
 
 pub(crate) fn current_time() -> u64 {


### PR DESCRIPTION
There have been some significant changes to the base64 crate in 0.21.x version, so this change keeps up with those.