### PR TITLE
Support the wasm32 target architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,15 @@ jsonwebtoken = "9"
 tokio = { version = "1.22.0", features = ["sync"] }
 thiserror = "1.0.37"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
-serde = {version = "1.0.147", features = ["derive"] }
+serde = { version = "1.0.147", features = ["derive"] }
 base64 = "0.22.0"
 log = "0.4.17"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { version = "0.4.42" }
+web-time = "1.1.0"
+
 [dev-dependencies]
-actix-web = {version = "4.2.1"}
+actix-web = { version = "4.2.1" }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,8 +7,14 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
+
+// The std::time::Instance panics on wasm, so we use web_time::Instance instead
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 use crate::{
     util::{current_time, decode_jwk},

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,8 @@
+// The std::time::SystemTime panics on wasm, so we use web_time::SystemTime instead
+#[cfg(not(target_family = "wasm"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_family = "wasm")]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use jsonwebtoken::{


### PR DESCRIPTION
The main changes are:
- Use of wasm_bindgen_futures::spawn_local instead of tokio::spawn (the latter is not supported in wasm32)
- Use of web_time::{Instance, SystemTime, UNIX_EPOCH} instead of std::time versions (the latter is not supported in wasm32)